### PR TITLE
Fail with the original error

### DIFF
--- a/lib/light_service_object.rb
+++ b/lib/light_service_object.rb
@@ -100,8 +100,8 @@ module LightServiceObject
         end
       end
       Dry::Monads.Success(result)
-    rescue Exception => error
-      Dry::Monads.Failure(error.message)
+    rescue StandardError => error
+      Dry::Monads.Failure(error)
     end
 
     def fail!(error)


### PR DESCRIPTION
https://dry-rb.org/gems/dry-monads/1.3/result/#adding-constraints-to-code-failure-code-values
this looks like it should work. we can use the context of the original error mainly backtrace. 

Move off exception to standard error. Exception  catches things like ctrl-c shutdown codes 
and other system level things.